### PR TITLE
Fix/declaration merging

### DIFF
--- a/libs/core/src/@types/index.ts
+++ b/libs/core/src/@types/index.ts
@@ -1,4 +1,4 @@
-export type ComponentPropsMap = Record<string, any>;
+export interface ComponentPropsMap {};
 
 export type ComponentConfig<K extends keyof ComponentPropsMap> = {
   /**

--- a/libs/core/src/@types/index.ts
+++ b/libs/core/src/@types/index.ts
@@ -1,6 +1,6 @@
 export interface ComponentPropsMap {};
 
-export type ComponentConfig<K extends keyof ComponentPropsMap> = {
+export type ComponentConfig<K extends keyof ComponentPropsMap = keyof ComponentPropsMap> = {
   /**
    * the name of the component (must be unique)
    */


### PR DESCRIPTION
# Summary of the changes

<!-- highlight the main point of the proposed changes -->

1. As `type` is not supported for declaration merging, the `ComponentPropsMap` type is changed to interface instead
2. Add default generic type for `ComponentConfig`
3.

---

## Reference to the cards / issues / tickets

<!-- eg: insert the links or the reference photos/images here -->

Some links or references here

---

## Screenshots / Videos / Examples

<!-- insert app screenshots here -->

Some links or references here

---

## Need review from

<!-- insert the person you wish to mention here -->
<!-- eg: @mentionPersonA -->

@mention someone here

---

Put an `x` in all the boxes that apply

## Checklist

- [x] I have performed a self-review of my own code, including:
  - Code is consistent with the project's style guidelines.
  - Code is well-organized and easy to read.
  - Code is adequately commented on where necessary.
- [x] I did lint my code locally prior to pushing and resolved any issues found.
- [x] The pull request fully complies with the project requirement
- [x] The pull request does not introduce any security vulnerabilities.
- [x] The pull request does not introduce new code smells, such as duplicate code or unnecessary complexity.
- [x] The pull request has been tested locally or in a staging environment and is working with no bugs
