### PR TITLE
Feat/playground example

### DIFF
--- a/apps/docs/docs/examples/basic-form.mdx
+++ b/apps/docs/docs/examples/basic-form.mdx
@@ -1,0 +1,86 @@
+---
+id: basic-form
+title: Basic form (core only)
+sidebar_label: Basic form
+---
+
+import Playground from '@site/src/components/Playground';
+
+A minimal `@formzk/core` form with yup validation. No MUI — renders plain HTML inputs. Edit the code on the left to see the change live.
+
+<Playground
+  withMui={false}
+  activeFile="App.tsx"
+  files={{
+    'App.tsx': `import React from 'react';
+import { Formzk, FormzkProvider } from '@formzk/core';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+
+const MyInput = ({ value = '', onChange, ...rest }: any) => (
+  <input
+    {...rest}
+    value={value}
+    onChange={(e) => onChange?.(e.target.value)}
+    style={{
+      display: 'block',
+      width: '100%',
+      padding: 8,
+      margin: '4px 0 12px',
+      border: '1px solid #ccc',
+      borderRadius: 4,
+    }}
+  />
+);
+
+const config = [{ name: 'MyInput', component: MyInput }];
+
+const schema = yup.object({
+  email: yup.string().required('Email is required').email(),
+  password: yup.string().required('Password is required').min(8, 'Min 8 chars'),
+});
+
+export default function App() {
+  return (
+    <FormzkProvider config={config}>
+      <div style={{ maxWidth: 360, padding: 16, fontFamily: 'system-ui' }}>
+        <h3>Sign in</h3>
+        <Formzk.Form
+          options={{ resolver: yupResolver(schema) }}
+          onSubmit={(values) => alert(JSON.stringify(values, null, 2))}
+        >
+          <label>Email</label>
+          <Formzk.Input name="email" component="MyInput" props={{ placeholder: 'you@example.com' }} />
+
+          <label>Password</label>
+          <Formzk.Input name="password" component="MyInput" props={{ type: 'password' }} />
+
+          <Formzk.Errors
+            render={(hasError, errors) =>
+              hasError ? (
+                <ul style={{ color: '#d33', fontSize: 14 }}>
+                  {errors.map((e, i) => <li key={i}>{e}</li>)}
+                </ul>
+              ) : null
+            }
+          />
+
+          <Formzk.Submit
+            render={(submit) => (
+              <button onClick={submit} style={{ padding: '8px 16px' }}>Sign in</button>
+            )}
+          />
+        </Formzk.Form>
+      </div>
+    </FormzkProvider>
+  );
+}
+`,
+  }}
+/>
+
+### What to try
+
+- Submit with empty fields → yup errors render.
+- Add a `Formzk.Reset` button next to Submit: `<Formzk.Reset render={(r) => <button onClick={r}>Reset</button>} />`.
+- Swap `MyInput` for a `<textarea>` component — no config changes needed in the form body.

--- a/apps/docs/docs/examples/config-driven.mdx
+++ b/apps/docs/docs/examples/config-driven.mdx
@@ -1,0 +1,106 @@
+---
+id: config-driven
+title: Config-driven form (MUI)
+sidebar_label: Config-driven (MUI)
+---
+
+import Playground from '@site/src/components/Playground';
+
+The MUI adapter's `Formzk.MUI.Form` accepts a declarative `config` array. Each sub-array is a row, each object is a column. Great for form-builder screens or admin dashboards.
+
+<Playground
+  activeFile="App.tsx"
+  files={{
+    'App.tsx': `import React from 'react';
+import { Formzk } from '@formzk/mui';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import { Button, Box } from '@mui/material';
+
+const schema = yup.object({
+  email: yup.string().required().email(),
+  password: yup.string().required().min(8),
+  role: yup.string().required(),
+  remember: yup.boolean(),
+});
+
+export default function App() {
+  return (
+    <Formzk.Native.Provider
+      config={[
+        {
+          name: 'TextField',
+          component: OutlinedInput,
+          props: { fullWidth: true, size: 'small' },
+        },
+      ]}
+    >
+      <Box sx={{ p: 2, maxWidth: 640 }}>
+        <Formzk.MUI.Form
+          name="profile-form"
+          options={{
+            resolver: yupResolver(schema),
+            defaultValues: { email: '', password: '', role: '', remember: false },
+          }}
+          configLayoutProps={{ containerProps: { spacing: 2 } }}
+          config={[
+            [
+              {
+                name: 'email',
+                label: 'Email',
+                component: 'TextField',
+                props: { placeholder: 'you@example.com' },
+                layoutProps: { sm: 6 },
+              },
+              {
+                name: 'password',
+                label: 'Password',
+                component: 'TextField',
+                props: { type: 'password' },
+                layoutProps: { sm: 6 },
+              },
+            ],
+            [
+              {
+                name: 'role',
+                label: 'Role',
+                component: 'Select',
+                props: {
+                  options: [
+                    { label: 'Admin', value: 'admin' },
+                    { label: 'Editor', value: 'editor' },
+                    { label: 'Viewer', value: 'viewer' },
+                  ],
+                },
+                layoutProps: { sm: 8 },
+              },
+              {
+                name: 'remember',
+                component: 'Checkbox',
+                valueKey: 'checked',
+                layout: 'contained',
+                label: 'Remember me',
+                layoutProps: { sm: 4 },
+              },
+            ],
+          ]}
+          onSubmit={(values) => alert(JSON.stringify(values, null, 2))}
+        >
+          <Formzk.MUI.Errors containerProps={{ sx: { my: 2 } }} />
+          <Formzk.MUI.Submit text="Save" />
+          <Formzk.MUI.Reset text="Clear" />
+        </Formzk.MUI.Form>
+      </Box>
+    </Formzk.Native.Provider>
+  );
+}
+`,
+  }}
+/>
+
+### What to try
+
+- Change a `layoutProps: { sm: 6 }` to `layoutProps: { sm: 12 }` to see the column take the full row.
+- Use the v6+ API: `layoutProps: { size: { xs: 12, sm: 6 } }`.
+- Add a third row with a `Switch` field — `{ name: 'enabled', component: 'Switch', valueKey: 'checked', label: 'Enabled', layout: 'contained' }`.

--- a/apps/docs/docs/examples/custom-component.mdx
+++ b/apps/docs/docs/examples/custom-component.mdx
@@ -1,0 +1,136 @@
+---
+id: custom-component
+title: Registering a custom component
+sidebar_label: Custom component
+---
+
+import Playground from '@site/src/components/Playground';
+
+Any React component that accepts a `value` + `onChange` pair can be registered. This example wires a `react-color`-style swatch picker — completely custom, yet still benefits from validation, form state, and the declarative API.
+
+<Playground
+  withMui={false}
+  activeFile="components/ColorSwatch.tsx"
+  files={{
+    'App.tsx': `import React from 'react';
+import { Formzk, FormzkProvider } from '@formzk/core';
+import { ColorSwatch } from './components/ColorSwatch';
+
+const config = [{ name: 'ColorSwatch', component: ColorSwatch }];
+
+export default function App() {
+  return (
+    <FormzkProvider config={config}>
+      <div style={{ padding: 16, fontFamily: 'system-ui', maxWidth: 420 }}>
+        <h3>Pick your brand colors</h3>
+        <Formzk.Form
+          options={{ defaultValues: { primary: '#8b5cf6', accent: '#10b981' } }}
+          onSubmit={(values) => alert(JSON.stringify(values, null, 2))}
+        >
+          <Formzk.Input
+            name="primary"
+            component="ColorSwatch"
+            props={{ label: 'Primary' }}
+          />
+          <Formzk.Input
+            name="accent"
+            component="ColorSwatch"
+            props={{ label: 'Accent' }}
+          />
+
+          <Formzk.Submit
+            render={(submit) => (
+              <button
+                onClick={submit}
+                style={{
+                  marginTop: 12,
+                  padding: '8px 16px',
+                  background: '#111',
+                  color: 'white',
+                  border: 0,
+                  borderRadius: 4,
+                }}
+              >
+                Save colors
+              </button>
+            )}
+          />
+        </Formzk.Form>
+      </div>
+    </FormzkProvider>
+  );
+}
+`,
+    'components/ColorSwatch.tsx': `import React from 'react';
+
+type Props = {
+  label?: string;
+  value?: string;
+  onChange?: (hex: string) => void;
+};
+
+const PRESETS = [
+  '#ef4444', '#f97316', '#facc15', '#10b981',
+  '#06b6d4', '#3b82f6', '#8b5cf6', '#ec4899',
+];
+
+export const ColorSwatch: React.FC<Props> = ({ label, value = '#000000', onChange }) => {
+  return (
+    <div style={{ margin: '8px 0 16px' }}>
+      {label && (
+        <div style={{ fontSize: 14, marginBottom: 6, color: '#555' }}>{label}</div>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            background: value,
+            border: '2px solid #eee',
+            borderRadius: 6,
+          }}
+        />
+        <code style={{ fontFamily: 'monospace', fontSize: 13 }}>{value}</code>
+        <div style={{ display: 'flex', gap: 4, marginLeft: 8 }}>
+          {PRESETS.map((hex) => (
+            <button
+              key={hex}
+              type="button"
+              onClick={() => onChange?.(hex)}
+              aria-label={hex}
+              style={{
+                width: 22,
+                height: 22,
+                background: hex,
+                border: value === hex ? '2px solid #111' : '1px solid #ddd',
+                borderRadius: 4,
+                cursor: 'pointer',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+`,
+    'types/formzk.d.ts': `// Augment ComponentPropsMap so TypeScript knows
+// what props ColorSwatch expects. In a real project
+// put this file somewhere in your \`include\` paths.
+import type { ColorSwatch } from '../components/ColorSwatch';
+
+declare module '@formzk/core' {
+  interface ComponentPropsMap {
+    ColorSwatch: React.ComponentProps<typeof ColorSwatch>;
+  }
+}
+export {};
+`,
+  }}
+/>
+
+### What to try
+
+- Click a swatch — form state updates, try submitting to see the current values.
+- Remove the `declare module` augmentation in `types/formzk.d.ts` — the form still runs (`ComponentPropsOf` falls back to `any`), you just lose autocomplete on `component="..."`.
+- Register a second custom component (e.g. a slider) and add a third `Formzk.Input` bound to it.

--- a/apps/docs/docs/examples/mui-adapter.mdx
+++ b/apps/docs/docs/examples/mui-adapter.mdx
@@ -1,0 +1,120 @@
+---
+id: mui-adapter
+title: MUI adapter — all inputs
+sidebar_label: MUI inputs
+---
+
+import Playground from '@site/src/components/Playground';
+
+Showcase of every pre-wired input shipping with `@formzk/mui` — `TextField`, `Checkbox`, `Switch`, `RadioGroup`, `CheckboxGroup`, `Select`. All values flow into the same form state and log on submit.
+
+<Playground
+  activeFile="App.tsx"
+  editorHeight={560}
+  files={{
+    'App.tsx': `import React from 'react';
+import { Formzk } from '@formzk/mui';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import { Box, Stack } from '@mui/material';
+
+export default function App() {
+  return (
+    <Formzk.Native.Provider
+      config={[
+        {
+          name: 'TextField',
+          component: OutlinedInput,
+          props: { fullWidth: true, size: 'small' },
+        },
+      ]}
+    >
+      <Box sx={{ p: 2, maxWidth: 640 }}>
+        <Formzk.MUI.Form
+          name="showcase"
+          options={{
+            defaultValues: {
+              email: '',
+              terms: false,
+              notify: true,
+              role: 'viewer',
+              permissions: [],
+              plan: 2,
+            },
+          }}
+          onSubmit={(values) => alert(JSON.stringify(values, null, 2))}
+        >
+          <Formzk.MUI.Item name="email" label="Email" component="TextField" />
+
+          <Formzk.MUI.Item
+            name="terms"
+            component="Checkbox"
+            valueKey="checked"
+            layout="contained"
+            label="I accept the terms"
+          />
+
+          <Formzk.MUI.Item
+            name="notify"
+            component="Switch"
+            valueKey="checked"
+            layout="contained"
+            label="Email notifications"
+          />
+
+          <Formzk.MUI.Item
+            name="role"
+            label="Role"
+            component="RadioGroup"
+            props={{
+              options: [
+                { label: 'Admin', value: 'admin' },
+                { label: 'Editor', value: 'editor' },
+                { label: 'Viewer', value: 'viewer' },
+              ],
+            }}
+          />
+
+          <Formzk.MUI.Item
+            name="permissions"
+            label="Permissions"
+            component="CheckboxGroup"
+            props={{
+              options: [
+                { label: 'Read', value: 'read' },
+                { label: 'Write', value: 'write' },
+                { label: 'Delete', value: 'delete' },
+              ],
+            }}
+          />
+
+          <Formzk.MUI.Item
+            name="plan"
+            label="Subscription plan"
+            component="Select"
+            props={{
+              options: [
+                { label: 'Free (0)', value: 0 },
+                { label: 'Pro (1)', value: 1 },
+                { label: 'Enterprise (2)', value: 2 },
+              ],
+            }}
+          />
+
+          <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+            <Formzk.MUI.Submit text="Save" />
+            <Formzk.MUI.Reset text="Reset" />
+          </Stack>
+        </Formzk.MUI.Form>
+      </Box>
+    </Formzk.Native.Provider>
+  );
+}
+`,
+  }}
+/>
+
+### What to try
+
+- Mix numeric and string `value`s in `Select` / `RadioGroup` options — both are supported since v1.1.
+- Change `layout` from the default `wrapped` to `contained` on `TextField` to see the label move into a help-text style.
+- Add a `caption="extra help"` prop to any `Formzk.MUI.Item` to show auxiliary text under the field.

--- a/apps/docs/docs/examples/overview.mdx
+++ b/apps/docs/docs/examples/overview.mdx
@@ -1,0 +1,20 @@
+---
+id: overview
+title: Examples & playground
+sidebar_label: Overview
+---
+
+Live, editable examples that run fully in your browser via [Sandpack](https://sandpack.codesandbox.io/). Every page has:
+
+- A code editor — **edit the source directly**, the preview re-runs on save.
+- A console tab — click **Console** at the bottom of the preview to see logs.
+- An **"Open in CodeSandbox"** button that forks the example into a full CodeSandbox project you can keep tinkering with.
+
+## Pages
+
+- [**Basic form**](./basic-form) — the smallest possible `@formzk/core` setup with yup validation and a custom input component. No MUI.
+- [**Config-driven form (MUI)**](./config-driven) — declarative `config` prop layout with the MUI adapter.
+- [**MUI adapter — all inputs**](./mui-adapter) — every pre-wired input: `TextField`, `Checkbox`, `Switch`, `RadioGroup`, `CheckboxGroup`, `Select`.
+- [**Custom component registration**](./custom-component) — register a bespoke color-swatch picker and augment `ComponentPropsMap` for full type-safety.
+
+> Each sandbox pulls `@formzk/core` and `@formzk/mui` from npm — the very same packages you'd install in your own project. So anything that works here works in your app.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,6 +15,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@codesandbox/sandpack-react": "^2.20.0",
+    "@codesandbox/sandpack-themes": "^2.0.21",
     "@docusaurus/core": "3.10.0",
     "@docusaurus/faster": "3.10.0",
     "@docusaurus/preset-classic": "3.10.0",

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -5,6 +5,18 @@ const sidebars: SidebarsConfig = {
     'getting-started',
     {
       type: 'category',
+      label: 'Examples & playground',
+      link: { type: 'doc', id: 'examples/overview' },
+      items: [
+        'examples/overview',
+        'examples/basic-form',
+        'examples/config-driven',
+        'examples/mui-adapter',
+        'examples/custom-component',
+      ],
+    },
+    {
+      type: 'category',
       label: '@formzk/core',
       link: { type: 'doc', id: 'core/overview' },
       items: ['core/overview', 'core/api', 'core/register-components'],

--- a/apps/docs/src/components/Playground/index.tsx
+++ b/apps/docs/src/components/Playground/index.tsx
@@ -15,7 +15,7 @@ type PlaygroundProps = {
    */
   activeFile?: string;
   /**
-   * Extra dependencies to install in the sandbox on top of react/react-dom.
+   * Extra dependencies to install in the sandbox on top of the default set.
    * Keys are package names, values are semver ranges.
    */
   dependencies?: Record<string, string>;
@@ -31,18 +31,77 @@ type PlaygroundProps = {
 };
 
 const DEFAULT_CORE_DEPS: Record<string, string> = {
-  '@formzk/core': 'latest',
+  '@formzk/core': '^1.0',
   'react-hook-form': '^7.40',
   yup: '^1.0',
   '@hookform/resolvers': '^3.0',
 };
 
 const DEFAULT_MUI_DEPS: Record<string, string> = {
-  '@formzk/mui': 'latest',
-  '@mui/material': '^7',
+  '@formzk/mui': '^1.0',
+  '@mui/material': '^5',
   '@emotion/react': '^11',
   '@emotion/styled': '^11',
 };
+
+/**
+ * Inner component rendered only in the browser — safe to call hooks and
+ * require() heavy client-only libraries here.
+ */
+function PlaygroundInner({
+  files,
+  activeFile,
+  dependencies = {},
+  withMui = true,
+  editorHeight = 480,
+}: PlaygroundProps) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const {
+    Sandpack,
+  } = require('@codesandbox/sandpack-react') as typeof import('@codesandbox/sandpack-react');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const {
+    atomDark,
+    githubLight,
+  } = require('@codesandbox/sandpack-themes') as typeof import('@codesandbox/sandpack-themes');
+
+  const { colorMode } = useColorMode();
+
+  const sandpackFiles: Record<string, string> = {};
+  for (const [path, code] of Object.entries(files)) {
+    sandpackFiles[path.startsWith('/') ? path : `/${path}`] = code;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <Sandpack
+        theme={colorMode === 'dark' ? atomDark : githubLight}
+        template="react-ts"
+        files={sandpackFiles}
+        options={{
+          editorHeight,
+          showConsoleButton: true,
+          showLineNumbers: true,
+          showTabs: true,
+          wrapContent: true,
+          activeFile: activeFile
+            ? activeFile.startsWith('/')
+              ? activeFile
+              : `/${activeFile}`
+            : undefined,
+          externalResources: [],
+        }}
+        customSetup={{
+          dependencies: {
+            ...DEFAULT_CORE_DEPS,
+            ...(withMui ? DEFAULT_MUI_DEPS : {}),
+            ...dependencies,
+          },
+        }}
+      />
+    </div>
+  );
+}
 
 /**
  * Live code playground powered by Sandpack. Runs fully in-browser, users
@@ -50,62 +109,11 @@ const DEFAULT_MUI_DEPS: Record<string, string> = {
  * CodeSandbox via the "Open in CodeSandbox" button.
  */
 export default function Playground(props: PlaygroundProps) {
-  const {
-    files,
-    activeFile,
-    dependencies = {},
-    withMui = true,
-    editorHeight = 480,
-  } = props;
-
   return (
-    <BrowserOnly fallback={<div className={styles.fallback}>Loading playground…</div>}>
-      {() => {
-        // dynamic import so Sandpack is only bundled client-side
-        const {
-          Sandpack,
-        } = require('@codesandbox/sandpack-react') as typeof import('@codesandbox/sandpack-react');
-        const {
-          atomDark,
-          githubLight,
-        } = require('@codesandbox/sandpack-themes') as typeof import('@codesandbox/sandpack-themes');
-        const { colorMode } = useColorMode();
-
-        const sandpackFiles: Record<string, string> = {};
-        for (const [path, code] of Object.entries(files)) {
-          sandpackFiles[path.startsWith('/') ? path : `/${path}`] = code;
-        }
-
-        return (
-          <div className={styles.wrapper}>
-            <Sandpack
-              theme={colorMode === 'dark' ? atomDark : githubLight}
-              template="react-ts"
-              files={sandpackFiles}
-              options={{
-                editorHeight,
-                showConsoleButton: true,
-                showLineNumbers: true,
-                showTabs: true,
-                wrapContent: true,
-                activeFile: activeFile
-                  ? activeFile.startsWith('/')
-                    ? activeFile
-                    : `/${activeFile}`
-                  : undefined,
-                externalResources: [],
-              }}
-              customSetup={{
-                dependencies: {
-                  ...DEFAULT_CORE_DEPS,
-                  ...(withMui ? DEFAULT_MUI_DEPS : {}),
-                  ...dependencies,
-                },
-              }}
-            />
-          </div>
-        );
-      }}
+    <BrowserOnly
+      fallback={<div className={styles.fallback}>Loading playground…</div>}
+    >
+      {() => <PlaygroundInner {...props} />}
     </BrowserOnly>
   );
 }

--- a/apps/docs/src/components/Playground/index.tsx
+++ b/apps/docs/src/components/Playground/index.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { useColorMode } from '@docusaurus/theme-common';
+
+import styles from './styles.module.css';
+
+type PlaygroundProps = {
+  /**
+   * Map of files available in the playground. Keys are file paths
+   * (e.g. 'App.tsx', '/components/MyInput.tsx'), values are source.
+   */
+  files: Record<string, string>;
+  /**
+   * The file to show in the editor pane by default.
+   */
+  activeFile?: string;
+  /**
+   * Extra dependencies to install in the sandbox on top of react/react-dom.
+   * Keys are package names, values are semver ranges.
+   */
+  dependencies?: Record<string, string>;
+  /**
+   * Whether to include `@formzk/mui` + peers in the sandbox. Default true
+   * so examples can mix adapter and core freely.
+   */
+  withMui?: boolean;
+  /**
+   * Editor height in px. Default 480.
+   */
+  editorHeight?: number;
+};
+
+const DEFAULT_CORE_DEPS: Record<string, string> = {
+  '@formzk/core': 'latest',
+  'react-hook-form': '^7.40',
+  yup: '^1.0',
+  '@hookform/resolvers': '^3.0',
+};
+
+const DEFAULT_MUI_DEPS: Record<string, string> = {
+  '@formzk/mui': 'latest',
+  '@mui/material': '^7',
+  '@emotion/react': '^11',
+  '@emotion/styled': '^11',
+};
+
+/**
+ * Live code playground powered by Sandpack. Runs fully in-browser, users
+ * can edit the code and see results immediately, or fork to a full
+ * CodeSandbox via the "Open in CodeSandbox" button.
+ */
+export default function Playground(props: PlaygroundProps) {
+  const {
+    files,
+    activeFile,
+    dependencies = {},
+    withMui = true,
+    editorHeight = 480,
+  } = props;
+
+  return (
+    <BrowserOnly fallback={<div className={styles.fallback}>Loading playground…</div>}>
+      {() => {
+        // dynamic import so Sandpack is only bundled client-side
+        const {
+          Sandpack,
+        } = require('@codesandbox/sandpack-react') as typeof import('@codesandbox/sandpack-react');
+        const {
+          atomDark,
+          githubLight,
+        } = require('@codesandbox/sandpack-themes') as typeof import('@codesandbox/sandpack-themes');
+        const { colorMode } = useColorMode();
+
+        const sandpackFiles: Record<string, string> = {};
+        for (const [path, code] of Object.entries(files)) {
+          sandpackFiles[path.startsWith('/') ? path : `/${path}`] = code;
+        }
+
+        return (
+          <div className={styles.wrapper}>
+            <Sandpack
+              theme={colorMode === 'dark' ? atomDark : githubLight}
+              template="react-ts"
+              files={sandpackFiles}
+              options={{
+                editorHeight,
+                showConsoleButton: true,
+                showLineNumbers: true,
+                showTabs: true,
+                wrapContent: true,
+                activeFile: activeFile
+                  ? activeFile.startsWith('/')
+                    ? activeFile
+                    : `/${activeFile}`
+                  : undefined,
+                externalResources: [],
+              }}
+              customSetup={{
+                dependencies: {
+                  ...DEFAULT_CORE_DEPS,
+                  ...(withMui ? DEFAULT_MUI_DEPS : {}),
+                  ...dependencies,
+                },
+              }}
+            />
+          </div>
+        );
+      }}
+    </BrowserOnly>
+  );
+}

--- a/apps/docs/src/components/Playground/styles.module.css
+++ b/apps/docs/src/components/Playground/styles.module.css
@@ -1,0 +1,14 @@
+.wrapper {
+  margin: 1.5rem 0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.fallback {
+  padding: 2rem;
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+  font-family: var(--ifm-font-family-monospace);
+}

--- a/apps/docs/yarn.lock
+++ b/apps/docs/yarn.lock
@@ -1067,6 +1067,153 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.4.0":
+  version "6.20.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz#4cfbc8b2e1e25f890ec34a081037e58b4e44143e"
+  integrity sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.1.3":
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.10.3.tgz#01877060befdec352e8300dec1f185489c300635"
+  integrity sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.6.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
+"@codemirror/lang-css@^6.0.0", "@codemirror/lang-css@^6.0.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.3.1.tgz#763ca41aee81bb2431be55e3cfcc7cc8e91421a3"
+  integrity sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/css" "^1.1.7"
+
+"@codemirror/lang-html@^6.4.0":
+  version "6.4.11"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.11.tgz#c46ba46ae642fd567cf05c4129005d2913ac248d"
+  integrity sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.12"
+
+"@codemirror/lang-javascript@^6.0.0", "@codemirror/lang-javascript@^6.1.2":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz#b9ea6b2f0383ed6895fae7888c0322541538f10a"
+  integrity sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.3.2", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0":
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.12.3.tgz#0b220182973a4c19850b29f7dd82aec1bbae3d7e"
+  integrity sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.9.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.9.5.tgz#c7da006f3335a33014799a7375c82df558e89f90"
+  integrity sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.35.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.2.0", "@codemirror/state@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.6.0.tgz#b88dbdc14aea4ace3c6d67bb77fe28bb84e4394e"
+  integrity sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
+"@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0", "@codemirror/view@^6.7.1":
+  version "6.41.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.41.1.tgz#8ecb39af289e7d03df0f3fb6e3c9b1f8747839bf"
+  integrity sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==
+  dependencies:
+    "@codemirror/state" "^6.6.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
+"@codesandbox/nodebox@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@codesandbox/nodebox/-/nodebox-0.1.8.tgz#2dc701005cedefac386f17a69a4c9a4f38c2325d"
+  integrity sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==
+  dependencies:
+    outvariant "^1.4.0"
+    strict-event-emitter "^0.4.3"
+
+"@codesandbox/sandpack-client@^2.19.8":
+  version "2.19.8"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz#45f936179aa8e012f11285ddd830911e6260a0f7"
+  integrity sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==
+  dependencies:
+    "@codesandbox/nodebox" "0.1.8"
+    buffer "^6.0.3"
+    dequal "^2.0.2"
+    mime-db "^1.52.0"
+    outvariant "1.4.0"
+    static-browser-server "1.0.3"
+
+"@codesandbox/sandpack-react@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-2.20.0.tgz#b298ad7159d01ae415a35612738a68251bc01323"
+  integrity sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==
+  dependencies:
+    "@codemirror/autocomplete" "^6.4.0"
+    "@codemirror/commands" "^6.1.3"
+    "@codemirror/lang-css" "^6.0.1"
+    "@codemirror/lang-html" "^6.4.0"
+    "@codemirror/lang-javascript" "^6.1.2"
+    "@codemirror/language" "^6.3.2"
+    "@codemirror/state" "^6.2.0"
+    "@codemirror/view" "^6.7.1"
+    "@codesandbox/sandpack-client" "^2.19.8"
+    "@lezer/highlight" "^1.1.3"
+    "@react-hook/intersection-observer" "^3.1.1"
+    "@stitches/core" "^1.2.6"
+    anser "^2.1.1"
+    clean-set "^1.1.2"
+    dequal "^2.0.2"
+    escape-carriage "^1.3.1"
+    lz-string "^1.4.4"
+    react-devtools-inline "4.4.0"
+    react-is "^17.0.2"
+
+"@codesandbox/sandpack-themes@^2.0.21":
+  version "2.0.21"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-themes/-/sandpack-themes-2.0.21.tgz#f1970f03537434fff008e9c9c3f6581b0e5940c2"
+  integrity sha512-CMH/MO/dh6foPYb/3eSn2Cu/J3+1+/81Fsaj7VggICkCrmRk0qG5dmgjGAearPTnRkOGORIPHuRqwNXgw0E6YQ==
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -2243,6 +2390,57 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
 
+"@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.5.2.tgz#d6840db13779e3f1b42e70c9a97c4086d12fae22"
+  integrity sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==
+
+"@lezer/css@^1.1.0", "@lezer/css@^1.1.7":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.3.3.tgz#b9800a57b338985c34be0dcaa1638ddf5cba0df1"
+  integrity sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
+  integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==
+  dependencies:
+    "@lezer/common" "^1.3.0"
+
+"@lezer/html@^1.3.12":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.13.tgz#6a1305ae3bd2c9c01f877f8a8dc1e15ec652d01c"
+  integrity sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.5.4.tgz#11746955f957d33c0933f17d7594db54a8b4beea"
+  integrity sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.3.0":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.10.tgz#b3acc36e5ad049b74ddb7719594e7e74d9161ff5"
+  integrity sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
+  integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
+
 "@mdx-js/mdx@^3.0.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-3.1.1.tgz#c5ffd991a7536b149e17175eee57a1a2a511c6d1"
@@ -2358,6 +2556,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@open-draft/deferred-promise@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
 
 "@peculiar/asn1-cms@^2.6.0", "@peculiar/asn1-cms@^2.6.1":
   version "2.6.1"
@@ -2508,6 +2711,19 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
+"@react-hook/intersection-observer@^3.1.1":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@react-hook/intersection-observer/-/intersection-observer-3.1.2.tgz#f6f0e42588e03c4afeac0276889d97927d67edc7"
+  integrity sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==
+  dependencies:
+    "@react-hook/passive-layout-effect" "^1.2.0"
+    intersection-observer "^0.10.0"
+
+"@react-hook/passive-layout-effect@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
+  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
+
 "@rspack/binding-darwin-arm64@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.11.tgz#ea43ac25a9ff99a9faf6c820f5d174a32974e95c"
@@ -2630,6 +2846,11 @@
     micromark-factory-space "^1.0.0"
     micromark-util-character "^1.1.0"
     micromark-util-symbol "^1.0.1"
+
+"@stitches/core@^1.2.6":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-1.2.8.tgz#dce3b8fdc764fbc6dbea30c83b73bfb52cf96173"
+  integrity sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==
 
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
@@ -3505,6 +3726,11 @@ algoliasearch@^5.37.0:
     "@algolia/requester-fetch" "5.51.0"
     "@algolia/requester-node-http" "5.51.0"
 
+anser@^2.1.1:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-2.3.5.tgz#3435896b68b93e5e744842499d0ce3e6f6d013ee"
+  integrity sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==
+
 ansi-align@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59"
@@ -3663,6 +3889,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 baseline-browser-mapping@^2.10.12:
   version "2.10.21"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz#136f9f181ee0d7ca6e3edbf42d9559763d2c1141"
@@ -3772,6 +4003,14 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bundle-name@^4.1.0:
   version "4.1.0"
@@ -3976,6 +4215,11 @@ clean-css@^5.2.2, clean-css@^5.3.3, clean-css@~5.3.2:
   integrity sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==
   dependencies:
     source-map "~0.6.0"
+
+clean-set@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/clean-set/-/clean-set-1.1.2.tgz#76d8bf238c3e27827bfa73073ecdfdc767187070"
+  integrity sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -4207,6 +4451,11 @@ cosmiconfig@^8.1.3, cosmiconfig@^8.3.5:
     parse-json "^5.2.0"
     path-type "^4.0.0"
 
+crelt@^1.0.5, crelt@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
+  integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
+
 cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -4402,6 +4651,14 @@ csstype@^3.2.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
+d@1, d@^1.0.1, d@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.2.tgz#2aefd554b81981e7dccf72d6842ae725cb17e5de"
+  integrity sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==
+  dependencies:
+    es5-ext "^0.10.64"
+    type "^2.7.2"
+
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
@@ -4501,7 +4758,7 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
-dequal@^2.0.0:
+dequal@^2.0.0, dequal@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -4627,6 +4884,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.0.3:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
@@ -4738,6 +5000,33 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   dependencies:
     es-errors "^1.3.0"
 
+es5-ext@^0.10.35, es5-ext@^0.10.62, es5-ext@^0.10.64, es5-ext@~0.10.14:
+  version "0.10.64"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.64.tgz#12e4ffb48f1ba2ea777f1fcdd1918ef73ea21714"
+  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
+  dependencies:
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    esniff "^2.0.1"
+    next-tick "^1.1.0"
+
+es6-iterator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3, es6-symbol@^3.1.1, es6-symbol@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.4.tgz#f4e7d28013770b4208ecbf3e0bf14d3bcb557b8c"
+  integrity sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==
+  dependencies:
+    d "^1.0.2"
+    ext "^1.7.0"
+
 esast-util-from-estree@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz#8d1cfb51ad534d2f159dc250e604f3478a79f1ad"
@@ -4762,6 +5051,11 @@ escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
+escape-carriage@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/escape-carriage/-/escape-carriage-1.3.1.tgz#842658e5422497b1232585e517dc813fc6a86170"
+  integrity sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==
 
 escape-goat@^4.0.0:
   version "4.0.0"
@@ -4795,6 +5089,16 @@ eslint-scope@5.1.1:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
+
+esniff@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/esniff/-/esniff-2.0.1.tgz#a4d4b43a5c71c7ec51c51098c1d8a29081f9b308"
+  integrity sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.62"
+    event-emitter "^0.3.5"
+    type "^2.7.2"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -4902,6 +5206,14 @@ eval@^0.1.8:
     "@types/node" "*"
     require-like ">= 0.1.1"
 
+event-emitter@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
 eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -4963,6 +5275,13 @@ express@^4.22.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+ext@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
+  dependencies:
+    type "^2.7.2"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -5623,6 +5942,11 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -5680,6 +6004,11 @@ inline-style-parser@0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.2.7.tgz#b1fc68bfc0313b8685745e4464e37f9376b9c909"
   integrity sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==
+
+intersection-observer@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
+  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -6193,6 +6522,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lz-string@^1.4.4:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 markdown-extensions@^2.0.0:
   version "2.0.0"
@@ -6918,7 +7252,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-"mime-db@>= 1.43.0 < 2", mime-db@^1.54.0:
+"mime-db@>= 1.43.0 < 2", mime-db@^1.52.0, mime-db@^1.54.0:
   version "1.54.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
@@ -7036,6 +7370,11 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -7171,6 +7510,16 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
+outvariant@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.0.tgz#e742e4bda77692da3eca698ef5bfac62d9fba06e"
+  integrity sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==
+
+outvariant@^1.3.0, outvariant@^1.4.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
 
 p-cancelable@^3.0.0:
   version "3.0.0"
@@ -8087,6 +8436,13 @@ rc@1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-devtools-inline@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz#e032a6eb17a9977b682306f84b46e683adf4bf68"
+  integrity sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==
+  dependencies:
+    es6-symbol "^3"
+
 react-dom@^19.0.0:
   version "19.2.5"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
@@ -8114,6 +8470,11 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-json-view-lite@^2.3.0:
   version "2.5.0"
@@ -8861,6 +9222,16 @@ srcset@^4.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-4.0.0.tgz#336816b665b14cd013ba545b6fe62357f86e65f4"
   integrity sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==
 
+static-browser-server@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/static-browser-server/-/static-browser-server-1.0.3.tgz#9030d141b99ed92c8eec1a7546b87548fd036f5d"
+  integrity sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.1.0"
+    dotenv "^16.0.3"
+    mime-db "^1.52.0"
+    outvariant "^1.3.0"
+
 "statuses@>= 1.5.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
@@ -8875,6 +9246,11 @@ std-env@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
+
+strict-event-emitter@^0.4.3:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz#ff347c8162b3e931e3ff5f02cfce6772c3b07eb3"
+  integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
@@ -8958,6 +9334,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
+style-mod@^4.0.0, style-mod@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
+  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
 
 style-to-js@^1.0.0:
   version "1.1.21"
@@ -9146,6 +9527,11 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+type@^2.7.2:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.3.tgz#436981652129285cc3ba94f392886c2637ea0486"
+  integrity sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -9369,6 +9755,11 @@ vfile@^6.0.0, vfile@^6.0.1:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 watchpack@^2.5.1:
   version "2.5.1"

--- a/libs/core/CHANGELOG.md
+++ b/libs/core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.1 (2026-04-24)
+
+### 🩹 Fixes
+
+- **libs:** force rollup output.interop=auto on CJS bundle ([3480fdc](https://github.com/louiskhenghao/formzk/commit/3480fdc))
+
+### ❤️ Thank You
+
+- louiskhenghao @louiskhenghao
+
 ## 1.1.0 (2026-04-25)
 
 ### 🚀 Features

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formzk/core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "description": "A powerful and flexible core library for form management in React applications, providing a headless form state management solution",
   "author": "Louis Loo <louiskhenghao@gmail.com> (https://github.com/louiskhenghao)",

--- a/libs/core/rollup.config.cjs
+++ b/libs/core/rollup.config.cjs
@@ -1,8 +1,13 @@
 /**
  * Rollup override for @formzk/core. Extends the default @nx/react bundle
- * config to rename the ESM output to `.esm.mjs` so Node correctly identifies
- * it as ES module at resolution time (without emitting
- * MODULE_TYPELESS_PACKAGE_JSON warnings).
+ * config to:
+ *   1. Rename the ESM output to `.esm.mjs` so Node identifies it as ES
+ *      module (no MODULE_TYPELESS_PACKAGE_JSON warnings).
+ *   2. Force `output.interop = 'auto'` on the CJS output so default imports
+ *      from CJS externals are unwrapped via `_interopDefault` at runtime.
+ *      Rollup 4 defaults to `'default'` which skips the helper and produces
+ *      a bundle that passes the whole module namespace object to React —
+ *      which crashes with "Element type is invalid ... got: object".
  */
 const nxReactRollup = require('@nx/react/plugins/bundle-rollup');
 
@@ -17,6 +22,9 @@ module.exports = (config) => {
           '.esm.mjs'
         );
       }
+    }
+    if (out.format === 'cjs') {
+      out.interop = 'auto';
     }
     return out;
   };

--- a/libs/mui/CHANGELOG.md
+++ b/libs/mui/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.1.1 (2026-04-24)
+
+### 🩹 Fixes
+
+- **libs:** force rollup output.interop=auto on CJS bundle ([3480fdc](https://github.com/louiskhenghao/formzk/commit/3480fdc))
+
+### 🧱 Updated Dependencies
+
+- Updated core to 1.1.1
+
+### ❤️ Thank You
+
+- louiskhenghao @louiskhenghao
+
 ## 1.1.0 (2026-04-24)
 
 ### 🚀 Features

--- a/libs/mui/package.json
+++ b/libs/mui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formzk/mui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "description": "A powerful form management library integrating Material-UI components with @formzk/core, providing seamless form creation and management with enhanced UI elements.",
   "author": "Louis Loo <louiskhenghao@gmail.com> (https://github.com/louiskhenghao)",

--- a/libs/mui/rollup.config.cjs
+++ b/libs/mui/rollup.config.cjs
@@ -1,8 +1,14 @@
 /**
  * Rollup override for @formzk/mui. Extends the default @nx/react bundle
- * config to rename the ESM output to `.esm.mjs` so Node correctly identifies
- * it as ES module at resolution time (without emitting
- * MODULE_TYPELESS_PACKAGE_JSON warnings).
+ * config to:
+ *   1. Rename the ESM output to `.esm.mjs` so Node identifies it as ES
+ *      module (no MODULE_TYPELESS_PACKAGE_JSON warnings).
+ *   2. Force `output.interop = 'auto'` on the CJS output so default imports
+ *      from CJS externals (e.g. `import Grid from '@mui/material/Grid'`)
+ *      are unwrapped via `_interopDefault` at runtime. Rollup 4 defaults
+ *      to `'default'` which skips the helper and produces a bundle that
+ *      passes the whole module namespace object to React — which crashes
+ *      with "Element type is invalid ... got: object".
  */
 const nxReactRollup = require('@nx/react/plugins/bundle-rollup');
 
@@ -17,6 +23,9 @@ module.exports = (config) => {
           '.esm.mjs'
         );
       }
+    }
+    if (out.format === 'cjs') {
+      out.interop = 'auto';
     }
     return out;
   };


### PR DESCRIPTION
# Summary of the changes                                                                     
                                                                                               
  1. **New live playground in the docs site.** Added a reusable `<Playground />` component at  
  `apps/docs/src/components/Playground` powered by                                           
  [Sandpack](https://sandpack.codesandbox.io/). It runs a full multi-file React sandbox in the 
  browser, resolves `@formzk/core` / `@formzk/mui` straight from npm, and exposes an "Open in
  CodeSandbox" fork button so readers can keep tinkering.
  2. **Four example pages under a new "Examples & playground" sidebar category:**
     - `/docs/examples/basic-form` — minimal `@formzk/core`-only form with yup validation and a
   plain `<input>` component.                                                                  
     - `/docs/examples/config-driven` — MUI adapter's declarative `config` array layout        
  (TextField + Select + Checkbox in a 2-row grid).                                             
     - `/docs/examples/mui-adapter` — every pre-wired MUI input (TextField, Checkbox, Switch,
  RadioGroup, CheckboxGroup, Select) on a single form.                                         
     - `/docs/examples/custom-component` — register a bespoke color-swatch picker and augment
  `ComponentPropsMap` for full type-safety.                                                    
  3. **Sandpack deps live in `apps/docs/package.json` only.** `@codesandbox/sandpack-react` and
   `@codesandbox/sandpack-themes` were not promoted to the root workspace — keeps the docs     
  app's isolated install pattern intact.                                                     
  4. **Robustness:** the playground is `BrowserOnly` (no SSR impact), respects Docusaurus      
  light/dark mode via `useColorMode()`, and accepts a `dependencies` prop so individual        
  examples can pin different MUI versions, add `@hookform/resolvers`, etc.
                                                                                               
  ---                                                                                        

  ## Reference to the cards / issues / tickets

  - Follows up on the Phase 4 docs work (Docusaurus scaffold at `apps/docs`).                  
  - Addresses the product request: "have a playground for developer to play around with
  example, or there is multi available example to cater for different use cases, and user can  
  freely edit or copy to code."                                                                       
                                                                                               
  ---
  Put an x in all the boxes that apply

  Checklist

  [x] I have performed a self-review of my own code, including:                                  
    [x] Code is consistent with the project's style guidelines.
    [x] Code is well-organized and easy to read.                                                 
    [x] Code is adequately commented on where necessary.                                       
  [x] I did lint my code locally prior to pushing and resolved any issues found.
  [x] The pull request fully complies with the project requirement                               
  [x] The pull request does not introduce any security vulnerabilities.
  [x] The pull request does not introduce new code smells, such as duplicate code or unnecessary 
  complexity.                                                                                
  [x] The pull request has been tested locally or in a staging environment and is working with no
   bugs 